### PR TITLE
fix: treat uxlc x tags correctly

### DIFF
--- a/src/bm_tools/uxlc/bible.py
+++ b/src/bm_tools/uxlc/bible.py
@@ -80,7 +80,8 @@ def get_book(name: str) -> list[list[list[str]]]:
                 if w.tag != "w":
                     continue
 
-                words.append(w.text)
+                # Some words have x tags within them, so strip them out
+                words.append("".join([e for e in w.itertext() if e > "z"]))
 
             verses[v_num] = words
 


### PR DESCRIPTION
Some words have something like `<w>abc<x>t</x>def</w>` which isn't intuativly parsed by python's ElementTree parser. It turns out that `.text` in this case is "abc" and not `abc<x>t</x>def` or `abctdef`.

This meant that part of the word was being ignored in parsing. To get the full set of text within the `w` tags, we need to use `.itertext()`. Throwing away any text group that contains non hebrew characters.